### PR TITLE
Bump CI node version to 20

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Env ⚙️
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
 
       - name: Checkout 🛎️
         uses: actions/checkout@v3


### PR DESCRIPTION
Bumping node version of CI action to 20 as 16 is deprecated